### PR TITLE
Fetch Grafana version from `/api/frontend/settings`

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -40,17 +40,16 @@ def test_collect_datasource_items_variable_all():
 
 def test_connect_success():
     wtf = GrafanaWtf("https://play.grafana.org")
-    health = wtf.health
-    assert "commit" in health
-    assert "version" in health
-    assert health.database == "ok"
+    build_info = wtf.build_info
+    assert "commit" in build_info
+    assert "version" in build_info
 
 
 def test_connect_failure():
     wtf = GrafanaWtf("http://localhost:1234")
     with pytest.raises(ConnectionError) as ex:
-        _ = wtf.health
-    assert ex.match("The request to http://localhost:1234/api/health failed")
+        _ = wtf.build_info
+    assert ex.match("The request to http://localhost:1234/api/frontend/settings failed")
 
 
 @patch("grafana_client.client.GrafanaClient.__getattr__")
@@ -64,5 +63,5 @@ def test_connect_version(mock_get):
 def test_connect_non_json_response():
     wtf = GrafanaWtf("https://example.org/")
     with pytest.raises(ConnectionError) as ex:
-        _ = wtf.health
-    assert ex.match("The request to https://example.org/api/health failed")
+        _ = wtf.build_info
+    assert ex.match("The request to https://example.org/api/frontend/settings failed")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -55,7 +55,7 @@ def test_connect_failure():
 @patch("grafana_client.client.GrafanaClient.__getattr__")
 def test_connect_version(mock_get):
     mock_get.return_value = Mock()
-    mock_get.return_value.return_value = {"commit": "14e988bd22", "database": "ok", "version": "9.0.1"}
+    mock_get.return_value.return_value = {"buildInfo": {"version": "9.0.1", "commit": "14e988bd22"}}
     wtf = GrafanaWtf("http://localhost:1234")
     assert wtf.version == "9.0.1"
 


### PR DESCRIPTION
AWS-managed Grafana API doesn't contain `/api/health` endpoint, which makes it impossible to use `grafana-wtf` with this kind of setup.

The proposal is to use `/api/frontend/settings` for the same purpose, which works for both regular and AWS-managed Grafana versions.

Fixes https://github.com/grafana-toolbox/grafana-wtf/issues/141