### PR TITLE
CI: Update dependencies for Docker-based test layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,4 +112,4 @@ install-tests: setup-virtualenv
 # -------
 
 grafana-start:
-	cd tests/grafana; docker-compose up
+	cd tests/grafana; docker compose up

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras = {
     "test": [
         "pytest<9",
         "pytest-cov<6",
-        "lovely-pytest-docker<2",
+        "lovely-pytest-docker>=1,<2",
         "grafanalib==0.7.1",
     ]
 }


### PR DESCRIPTION
## About
- The v1 `docker-compose` command no longer exists on contemporary environments.
- GH-143 fails to conclude, because it errors out trying to use `docker-compose`.
