### PR TITLE
CI: Verify support on Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest" ]
-        python-version: [ "3.8", "3.12" ]
+        python-version: [ "3.8", "3.13" ]
         grafana-version: [ "6.7.6", "7.5.17", "8.5.27", "9.5.18", "10.3.5", "10.4.1", "11.1.0" ]
 
     env:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ grafana-wtf changelog
 
 in progress
 ===========
+- CI: Verified support on Python 3.13
 
 2024-09-29 0.20.1
 =================

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Communications",
         "Topic :: Database",
         "Topic :: Internet",


### PR DESCRIPTION
## About
[Python 3.13.0](https://www.python.org/downloads/release/python-3130/) has been released on Oct. 7, 2024. This PR intends to add CI verification.

## References
- https://github.com/grafana-toolbox/grafana-client/pull/192
- https://github.com/crate/crate-python/pull/653
