### PR TITLE
CI+Sandbox: Stop using `setup.py`, instead only use `pip`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,7 @@ install-releasetools: setup-virtualenv
 	@$(pip) install --quiet --requirement requirements-release.txt --upgrade
 
 install-tests: setup-virtualenv
-	@$(pip) install --quiet --editable .[test] --upgrade
-	@$(python) setup.py --quiet develop
+	@$(pip) install --quiet --upgrade --editable='.[test]'
 	@touch $(venvpath)/bin/activate
 	@mkdir -p .pytest_results
 


### PR DESCRIPTION
## About
A little modernization, preparing to phase out `setup.py`.

## Details
```
/home/runner/work/grafana-wtf/grafana-wtf/.venv/lib/python3.13/site-packages/setuptools/command/develop.py:41: EasyInstallDeprecationWarning: easy_install command is deprecated.
 /home/runner/work/grafana-wtf/grafana-wtf/.venv/lib/python3.13/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!
        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.
        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************
!!
```

## References
- https://github.com/grafana-toolbox/grafana-wtf/actions/runs/11407189355/job/31742761728?pr=147#step:5:25
