### PR TITLE
Fix `DatasourceItem` re. `Unexpected keyword argument 'default'`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ grafana-wtf changelog
 in progress
 ===========
 - CI: Verified support on Python 3.13
+- Fixed `DatasourceItem` re. `Unexpected keyword argument 'default'`.
+  Thank you, @jwoodhouse.
 
 2024-09-29 0.20.1
 =================

--- a/grafana_wtf/model.py
+++ b/grafana_wtf/model.py
@@ -167,6 +167,7 @@ class DatasourceItem:
     name: Optional[str] = None
     type: Optional[str] = None
     url: Optional[str] = None
+    default: Optional[str] = None
 
     @classmethod
     def from_payload(cls, payload: any):


### PR DESCRIPTION
## About
Compensate for a dashboard that apparently trips processing, as reported by @jwoodhouse. Thanks!

## References
- https://github.com/grafana-toolbox/grafana-wtf/issues/150

## Q&A
Is it the right fix? / Is the fix right?

/cc @sanadhis, @rlauzon-ea 
