### PR TITLE
Update channel scanning

### DIFF
--- a/grafana_wtf/commands.py
+++ b/grafana_wtf/commands.py
@@ -40,7 +40,7 @@ def run():
       grafana-wtf [options] log [<dashboard_uid>] [--number=<count>] [--head=<count>] [--tail=<count>] [--reverse] [--sql=<sql>]
       grafana-wtf [options] plugins list [--id=]
       grafana-wtf [options] plugins status [--id=]
-      grafana-wtf [options] channels [--id=]
+      grafana-wtf [options] channels [--uid=]
       grafana-wtf --version
       grafana-wtf (-h | --help)
 
@@ -346,8 +346,8 @@ def run():
         output_results(output_format, response)
 
     if options.channels:
-        if options.id:
-            response = engine.channels_list_by_id(options.id)
+        if options.uid:
+            response = engine.channels_list_by_uid(options.uid)
         else:
             response = engine.channels_list()
         output_results(output_format, response)


### PR DESCRIPTION
Hi @amotl,

I again felt the need of seeing in what dashboards different notification channels are used as previously described by me in https://github.com/grafana-toolbox/grafana-wtf/issues/82, so I updated the code to satisfy my needs. However, there are some things worth mentioning:
* this only searches through alerts that were created before Grafana 8, because after this alerting stopped being tied to the panel/dashboard, so this information is not available anymore. The command doesn't break on occasions like this, it just doesn't return any information about the related panels.
* even then the structure of the alert information differs slightly between the dashboards, hence my update includes the sketchy `if-elif`
* if you still think that this is something useful for the `grafana-wtf`, I might add support for the search by the channel name. Currently you need to use channel uid and that is completely fine for me, but having the ability to search by channel name would make it a little bit more user-friendly

Let me know what you think!