### PR TITLE
fix: variable datasources shown as missing and unused datasource

### DIFF
--- a/grafana_wtf/core.py
+++ b/grafana_wtf/core.py
@@ -663,10 +663,10 @@ class Indexer:
             # Datasources defined as variables.
             if "type" in node and node["type"] == "datasource":
                 values = to_list(node.get("current", {}).get("value"))
-                for ds_name in values:
-                    datasource = self.datasource_by_name.get(ds_name)
+                for ds_uid in values:
+                    datasource = self.datasource_by_uid.get(ds_uid)
                     if datasource is None:
-                        log.warning(f"Data source '{ds_name}' not found")
+                        log.warning(f"Data source '{ds_uid}' not found")
                         continue
                     ds = dict(
                         type=datasource.get("type"),


### PR DESCRIPTION
This PR fixes a bug where datasources that were being used in dashboards through variables were being wrongly categorised as unused (in `explore datasources`) and missing (in `explore dashboards`).

The full description of the problem can be seen in the issue #164 along with steps to reproduce it.