### PR TITLE
CI: Do not cache packages twice, per pip and uv. Just cache with uv.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,9 +45,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
-          cache: 'pip'
-          cache-dependency-path: 'setup.py'
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
What the title says.