### PR TITLE
Update verlib2 version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requires = [
     "docopt-ng>=0.6.2,<0.10",
     "munch>=2.5.0,<5",
     "tqdm>=4.60.0,<5",
-    "verlib2>=0.3,<0.4",
+    "verlib2>=0.3.1,<0.4",
     # Filtering
     f"pandas<2.3; {no_linux_on_arm}",
     f"duckdb<1.3; {no_linux_on_arm}",


### PR DESCRIPTION
Hi @amotl,

I wasn't able to run `grafana-wtf` with the `verlib2 0.3.0`, so I think this change should prevent this problem.