### PR TITLE
Fix concurrency check because of segmentation faults happening

### DIFF
--- a/grafana_wtf/core.py
+++ b/grafana_wtf/core.py
@@ -223,7 +223,7 @@ class GrafanaEngine:
         if self.progressbar:
             self.start_progressbar(len(self.data.dashboard_list))
 
-        if self.concurrency is None or self.concurrency <= 1:
+        if self.concurrency is None or self.concurrency <= 1 or hasattr(self.grafana.client.s, "cache"):
             self.fetch_dashboards()
         else:
             self.fetch_dashboards_parallel()


### PR DESCRIPTION
Fix concurrency check to include cache attribute in Grafana client to fix segmentation fault.

Tried to run `grafana-wtf find <my search string> --verbose` and got the following error:

```sh
74916 segmentation fault  .venv/bin/grafana-wtf find <my search string> --verbose
/Users/*****/.pyenv/versions/3.13.2/lib/python3.13/multiprocessing/resource_tracker.py:277: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown: {'/mp-zcrp9b0y'}
```

This fixes it.