### PR TITLE
Fix collecting data sources defined by dashboard variables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ in progress
 ===========
 - Fixed 404 error on "dash-folder" type when enumerating dashboards.
   Thanks, @oxy-star and @GarbageYard.
+- Fixed collecting data sources defined by dashboard variables. Thanks,
+  @GrgDev, @cronosnull, and @nikodemas.
 
 2025-03-18 0.23.0
 =================

--- a/grafana_wtf/core.py
+++ b/grafana_wtf/core.py
@@ -715,10 +715,10 @@ class Indexer:
             # Datasources defined as variables.
             if "type" in node and node["type"] == "datasource":
                 values = to_list(node.get("current", {}).get("value"))
-                for ds_uid in values:
-                    datasource = self.datasource_by_uid.get(ds_uid)
+                for ds_name in values:
+                    datasource = self.datasource_by_name.get(ds_name)
                     if datasource is None:
-                        log.warning(f"Data source '{ds_uid}' not found")
+                        log.warning(f"Data source '{ds_name}' not found")
                         continue
                     ds = dict(
                         type=datasource.get("type"),


### PR DESCRIPTION
## Problem

When data sources are defined by dashboard variables, a ton of warnings like `Data source 'datasource-3' not found` are emitted.

## Observations

It looks like resolving this bit of information beared a programming error.

## Solution

@cronosnull [suggested](https://github.com/grafana-toolbox/grafana-wtf/issues/187#issuecomment-2866458945) an excellent improvement. Thanks!

> I think the values in the variables are data source names, but not completely sure, so I would support both cases.
